### PR TITLE
Refer to policy before checking user role

### DIFF
--- a/src/Resources/TokenResource.php
+++ b/src/Resources/TokenResource.php
@@ -42,6 +42,10 @@ class TokenResource extends Resource
                             ->hidden(function () {
                                 $user = auth()->user();
 
+                                $policy = config('api-service.models.token.enable_policy', true);
+
+                                if ($policy === false) return false;
+
                                 return ! $user->hasRole('super_admin');
                             })
                             ->required(),


### PR DESCRIPTION
While trying to create a token, if the user policy is set to false, the user role should not be checked.