### PR TITLE
change instanceOf to is_subclass_of

### DIFF
--- a/src/Http/Handlers.php
+++ b/src/Http/Handlers.php
@@ -181,7 +181,7 @@ class Handlers
     {
         $model = static::getModel();
 
-        if($model instanceof HasAllowedFilters) {
+        if (is_subclass_of($model, HasAllowedFilters::class)) {
             return $model::getAllowedFilters();
         }
 


### PR DESCRIPTION
change instanceOf to is_subclass_of, instanceOf return false even tho we implement the function in our model. but when I change it to is_subclass_of it works

<img width="452" alt="image" src="https://github.com/user-attachments/assets/c8395221-a145-4b8d-83a3-44dceb0cc671">


here is my class I did implement it, but like I show you, the image error, it doesn't work if use instaceOf
```
class User extends Authenticatable implements FilamentUser, HasAllowedFields, HasAllowedSorts, HasAllowedFilters

// Which fields can be used to filter the results through the query string
    public static function getAllowedFilters(): array
    {
        return ['name'];
    }
```

thank you

