### PR TITLE
add scramble description for handler and extra header parameters block

### DIFF
--- a/src/ApiServiceServiceProvider.php
+++ b/src/ApiServiceServiceProvider.php
@@ -14,6 +14,8 @@ use Rupadana\ApiService\Commands\MakeApiHandlerCommand;
 use Rupadana\ApiService\Commands\MakeApiRequest;
 use Rupadana\ApiService\Commands\MakeApiServiceCommand;
 use Rupadana\ApiService\Commands\MakeApiTransformerCommand;
+use Rupadana\ApiService\Scramble\Extensions\HandlerDescription;
+use Rupadana\ApiService\Scramble\Extensions\HeaderParameters;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -61,7 +63,12 @@ class ApiServiceServiceProvider extends PackageServiceProvider
         }
     }
 
-    public function packageRegistered(): void {}
+    public function packageRegistered(): void {
+        if (class_exists(Scramble::class)) {
+            Scramble::registerExtension(HeaderParameters::class);
+            Scramble::registerExtension(HandlerDescription::class);
+        }
+    }
 
     public function packageBooted(): void
     {

--- a/src/Http/Handlers.php
+++ b/src/Http/Handlers.php
@@ -26,6 +26,12 @@ class Handlers
     public static ?string $resource = null;
     protected static string $keyName = 'id';
     protected static bool $public = false;
+
+    public static ?string $description = null;
+
+    public static ?array $extraHeaders = [];
+
+
     const POST = 'post';
     const GET = 'get';
     const DELETE = 'delete';
@@ -40,6 +46,16 @@ class Handlers
         }
     }
 
+    public static function description(): ?string
+    {
+        return static::$description;
+    }
+
+    public static function extraHeaders(): ?array
+    {
+        return static::$extraHeaders;
+    }
+
     public static function getMethod()
     {
         return static::$method;
@@ -51,8 +67,8 @@ class Handlers
 
         $router
             ->{$method}(static::$uri, [static::class, 'handler'])
-            ->name(static::getKebabClassName())
-            ->middleware(static::getRouteMiddleware());
+                ->name(static::getKebabClassName())
+                ->middleware(static::getRouteMiddleware());
     }
 
     public static function isPublic(): bool
@@ -119,7 +135,7 @@ class Handlers
 
     public static function getApiTransformer(): ?string
     {
-        if (! method_exists(static::$resource, 'getApiTransformer')) {
+        if (!method_exists(static::$resource, 'getApiTransformer')) {
             return DefaultTransformer::class;
         }
 

--- a/src/Scramble/Extensions/HandlerDescription.php
+++ b/src/Scramble/Extensions/HandlerDescription.php
@@ -1,0 +1,35 @@
+<?php
+namespace Rupadana\ApiService\Scramble\Extensions;
+use Dedoc\Scramble\Support\RouteInfo;
+use Dedoc\Scramble\Support\Generator\Schema;
+use Dedoc\Scramble\Support\Generator\Operation;
+use Dedoc\Scramble\Support\Generator\Parameter;
+use Dedoc\Scramble\Extensions\OperationExtension;
+use Dedoc\Scramble\Support\Generator\Types\StringType;
+
+class HandlerDescription extends OperationExtension
+{
+    public function handle(Operation $operation, RouteInfo $routeInfo)
+    {
+
+        $action = $routeInfo->route->getAction('uses');
+        if (is_string($action) && str_contains($action, '@')) {
+            [$class, $method] = explode('@', $action);
+        } else {
+            // Cas d’un __invoke, ou autre
+            $class = $action;
+            $method = null;
+        }
+
+
+
+
+        if (class_exists($class) && method_exists($class, 'description')) {
+            $desc = $class::description();
+            if ($desc) {
+                $operation->description($desc);
+            }
+        }
+
+    }
+}

--- a/src/Scramble/Extensions/HeaderParameters.php
+++ b/src/Scramble/Extensions/HeaderParameters.php
@@ -1,0 +1,42 @@
+<?php
+namespace Rupadana\ApiService\Scramble\Extensions;
+use Dedoc\Scramble\Support\RouteInfo;
+use Dedoc\Scramble\Support\Generator\Schema;
+use Dedoc\Scramble\Support\Generator\Operation;
+use Dedoc\Scramble\Support\Generator\Parameter;
+use Dedoc\Scramble\Extensions\OperationExtension;
+use Dedoc\Scramble\Support\Generator\Types\StringType;
+
+class HeaderParameters extends OperationExtension
+{
+    public function handle(Operation $operation, RouteInfo $routeInfo)
+    {
+        $action = $routeInfo->route->getAction('uses');
+        if (is_string($action) && str_contains($action, '@')) {
+            [$class, $method] = explode('@', $action);
+        } else {
+            // Cas d’un __invoke, ou autre
+            $class = $action;
+            $method = null;
+        }
+
+        if (class_exists($class) && method_exists($class, 'extraHeaders')) {
+            $extraHeaders = $class::extraHeaders();
+            if (count($extraHeaders) > 0) {
+                foreach ($extraHeaders as $key => $value) {
+                    $operation->addParameters([
+                        Parameter::make($key, 'header')
+                            ->setSchema(
+                                Schema::fromType(new StringType())
+                            )
+                            ->description($value['description'] ?? "")
+                            ->required($value['required'] ?? false)
+                            ->example($value['sample'] ?? "")
+                    ]);
+                }
+            }
+
+        }
+
+    }
+}


### PR DESCRIPTION
Hi,

Here are some helper functions for Scramble documentation. I'm not sure if they're usable or interesting, but I use them for my documentation.


adding a description for handlers 
![image](https://github.com/user-attachments/assets/e32a3c56-50cd-468e-a4f0-e83b9b206cd6)

and extraHEaders parameters

![image](https://github.com/user-attachments/assets/10e0c647-cadd-4aa2-adaa-e3e37d182d9d)
![image](https://github.com/user-attachments/assets/7199c80e-3362-4f71-9ebf-e90502512b78)
![image](https://github.com/user-attachments/assets/bae43e49-17f7-46ca-b05e-dda47a043306)

```
class CreateHandler extends Handlers
{

    public static ?string $description = "This endpoint expects a JSON containing the order metadata and the list of order_items.
";

    public static ?array $extraHeaders = [
        "Client-Id" => [
            'sample' => '123456789',
            'required' => true,
            'description' => 'Identifiant unique du client',
        ]
    ];
    }
```
    
    
Thanks for your amazing and simple to use api pluging for filament
    
    