### PR TITLE
[Feature] make the stubs publishable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ php artisan make:filament-api-handler Blog
 If you want to customize the generated handlers, you can export them using the following command.
 
 ```bash
-php artisan vendor:publish --tag=api-service-config
+php artisan vendor:publish --tag=api-service-stubs
 ```
 
 ### Transform API Response

--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ or
 php artisan make:filament-api-handler Blog
 ```
 
+#### Customize Handlers
+If you want to customize the generated handlers, you can export them using the following command.
+
+```bash
+php artisan vendor:publish --tag=api-service-config
+```
+
 ### Transform API Response
 
 ```bash

--- a/src/ApiServiceServiceProvider.php
+++ b/src/ApiServiceServiceProvider.php
@@ -92,6 +92,15 @@ class ApiServiceServiceProvider extends PackageServiceProvider
                 SecurityScheme::http('bearer')
             );
         });
+
+        // Publish Stubs
+        if ($this->app->runningInConsole()) {
+            foreach (app(Filesystem::class)->files(__DIR__ . '/../stubs/') as $file) {
+                $this->publishes([
+                    $file->getRealPath() => base_path("stubs/filament/{$file->getFilename()}"),
+                ], static::$name . '-stubs');
+            }
+        }
     }
 
     protected function getAssetPackageName(): ?string


### PR DESCRIPTION
## The motivation
I'm working on a project with PHPStan enabled at the max level. Every time I generate an API service, PHPStan complains about the generated files, and I've got to fix them manually.

## The fix
After digging for a bit, I learned that this package uses [CanManipulateFiles](https://github.com/filamentphp/filament/blob/3.x/packages/support/src/Commands/Concerns/CanManipulateFiles.php) trait, which checks for the existence of the stub under `stubs/filament` before using the one in the package.
So easily enough, I borrowed a couple of lines from filament's repository https://github.com/filamentphp/filament/blob/3.x/packages/panels/src/FilamentServiceProvider.php#L95-L100 to satisfy the need.

### Suggestion
I want to open another PR to correctly type the generated files so PHPStan can live with them peacefully if @rupadana doesn't mind it

## Screenshots
<img width="597" alt="image" src="https://github.com/user-attachments/assets/c5d99def-61f3-4aeb-9a79-2519a591c6dd" />
<img width="1334" alt="image" src="https://github.com/user-attachments/assets/d1064087-ce94-45f0-96b2-d8872d3ab5e2" />

