### PR TITLE
 Adding any additional middleware you want to apply to the logout and login route using config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ return [
             'sort' => -1,
             'icon' => 'heroicon-o-key',
             'should_register_navigation' => false,
-        ]
+        ],
     ],
     'models' => [
         'token' => [
@@ -64,7 +64,19 @@ return [
     'tenancy' => [
         'enabled' => false,
         'awareness' => false,
-    ]
+    ],
+    'login-rules' => [
+        'email' => 'required|email',
+        'password' => 'required',
+    ],
+    'login-middleware' => [
+        // Add any additional middleware you want to apply to the login route
+    ],
+    'logout-middleware' => [
+        'auth:sanctum',
+        // Add any additional middleware you want to apply to the logout route
+    ],
+    'use-spatie-permission-middleware' => true,
 ];
 ```
 

--- a/config/api-service.php
+++ b/config/api-service.php
@@ -27,5 +27,12 @@ return [
         'email' => 'required|email',
         'password' => 'required',
     ],
+    'login-middleware' => [
+        // Add any additional middleware you want to apply to the login route
+    ],
+    'logout-middleware' => [
+        'auth:sanctum',
+        // Add any additional middleware you want to apply to the logout route
+    ],
     'use-spatie-permission-middleware' => true,
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,10 +10,10 @@ use Rupadana\ApiService\Http\Controllers\AuthController;
 Route::prefix('api')
     ->name('api.')
     ->group(function (Router $router) {
-        $router->post('/auth/login', [AuthController::class, 'login']);
-        $router->post('/auth/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
+        $router->post('/auth/login', [AuthController::class, 'login'])->middleware(config('api-service.login-middleware', []));
+        $router->post('/auth/logout', [AuthController::class, 'logout'])->middleware(config('api-service.logout-middleware', ['auth:sanctum']));
 
-        if (ApiService::tenancyAwareness() && (! ApiService::isRoutePrefixedByPanel() || ! ApiService::isTenancyEnabled())) {
+        if (ApiService::tenancyAwareness() && (!ApiService::isRoutePrefixedByPanel() || !ApiService::isTenancyEnabled())) {
             throw new InvalidTenancyConfiguration("Tenancy awareness is enabled!. Please set 'api-service.route.panel_prefix=true' and 'api-service.tenancy.enabled=true'");
         }
 
@@ -43,7 +43,7 @@ Route::prefix('api')
                         });
                 }
 
-                if (! ApiService::tenancyAwareness()) {
+                if (!ApiService::tenancyAwareness()) {
                     Route::prefix($panelRoutePrefix)
                         ->name($panelNamePrefix)
                         ->middleware($middlewares)


### PR DESCRIPTION
 Adding any additional middleware you want to apply to the logout and login route using config
 
//rupadana/filament-api-service/routes/api.php

```php
 $router->post('/auth/login', [AuthController::class, 'login'])->middleware(config('api-service.login-middleware', []));
 $router->post('/auth/logout', [AuthController::class, 'logout'])->middleware(config('api-service.logout-middleware', ['auth:sanctum']));
 ```
//rupadana/filament-api-service/config/api-service.php

```php
  'login-middleware' => [
        // Add any additional middleware you want to apply to the login route
    ],
    'logout-middleware' => [
        'auth:sanctum',
        // Add any additional middleware you want to apply to the logout route
    ],
 ```